### PR TITLE
Add project for .NET Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,9 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+**/Properties/launchSettings.json

--- a/json2map.core.sln
+++ b/json2map.core.sln
@@ -1,0 +1,35 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{96223035-36F0-4ED8-9025-E7038C751F73}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+	EndProjectSection
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Json2map.Core", "json2map\Json2map.Core.xproj", "{9FF9908F-2B88-4DB7-95D8-5F6D22CD611A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9FF9908F-2B88-4DB7-95D8-5F6D22CD611A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9FF9908F-2B88-4DB7-95D8-5F6D22CD611A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FF9908F-2B88-4DB7-95D8-5F6D22CD611A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9FF9908F-2B88-4DB7-95D8-5F6D22CD611A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84D22008-BD5B-478C-8E64-129B32BEF941}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84D22008-BD5B-478C-8E64-129B32BEF941}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84D22008-BD5B-478C-8E64-129B32BEF941}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84D22008-BD5B-478C-8E64-129B32BEF941}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7EB2E51-BC84-4ED9-AD0A-65ECD66FA5F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7EB2E51-BC84-4ED9-AD0A-65ECD66FA5F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7EB2E51-BC84-4ED9-AD0A-65ECD66FA5F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7EB2E51-BC84-4ED9-AD0A-65ECD66FA5F6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/json2map/json2map.core.xproj
+++ b/json2map/json2map.core.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>9ff9908f-2b88-4db7-95d8-5f6d22cd611a</ProjectGuid>
+    <RootNamespace>Json2map</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/json2map/project.json
+++ b/json2map/project.json
@@ -1,0 +1,14 @@
+﻿{
+  "version": "2.0.0",
+
+  "dependencies": {
+    "NETStandard.Library": "1.6.0",
+    "Newtonsoft.Json": "9.0.1"
+  },
+
+  "frameworks": {
+    "netstandard1.6": {
+      "imports": "dnxcore50"
+    }
+  }
+}


### PR DESCRIPTION
Adds a separate solution and project for targeting .NET Core. They sit next to the other solution/projects and reference the same files. No code changes were necessary. MSTest isn't stable for Core yet so the unit tests are unported.